### PR TITLE
Remove yarn as it's not required

### DIFF
--- a/chassis.yaml
+++ b/chassis.yaml
@@ -5,6 +5,3 @@
 #
 # Values: 2
 version: 2
-
-dependencies:
-  - yarn


### PR DESCRIPTION
Fixes #10.

People who have provisioned a Chassis box with this extension can remove yarn by adding the following lines to one of their configuration files:
```
disabled_extensions:
  - chassis/yarn
```
then running `vagrant provision`